### PR TITLE
Over 14k packages at CRAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ while most R packages run right out of the box.
 
 *Call it a tie.*
 
-[CRAN](https://cran.r-project.org/) has over 12,000
+[CRAN](https://cran.r-project.org/) has over 14,000
 packages. [PyPI](https://pypi.org/) has over 183,000,
 but it seems thin on Data Science.
 


### PR DESCRIPTION
See eg the top of https://cloud.r-project.org/web/packages/index.html which currently lists 14366.